### PR TITLE
switch to Asciidoctor 2.0 with build-in Rouge integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ gem "jekyll", "~> 3.8.5"
 
 group :jekyll_plugins do
   gem 'jekyll-asciidoc'
-  gem 'asciidoctor-rouge'
+  #gem 'asciidoctor-rouge'
 end
 
+gem 'asciidoctor', '~> 2.0.1'
 gem 'rouge'
 gem 'vertx-howtos-jekyll-theme'
 


### PR DESCRIPTION
Note that the asciidoctor-rouge gem is no longer needed.